### PR TITLE
Add `COMPLETE` pragma to `FCompose`

### DIFF
--- a/src/Data/HKD.hs
+++ b/src/Data/HKD.hs
@@ -490,9 +490,10 @@ deriving stock instance Ord (f (F1 a g)) => Ord (FCompose a f g)
 deriving stock instance Show (f (F1 a g)) => Show (FCompose a f g)
 deriving stock instance Read (f (F1 a g)) => Read (FCompose a f g)
 
-pattern FCompose :: Functor f => f (g a) -> FCompose a f g 
+pattern FCompose :: Functor f => f (g a) -> FCompose a f g
 pattern FCompose { runFCompose } <- FCompose' (fmap runF1 -> runFCompose) where
   FCompose f = FCompose' (fmap F1 f)
+{-# complete FCompose :: FCompose #-}
 
 deriving stock instance
   ( Typeable k


### PR DESCRIPTION
`distributive` currently produces `-Wincomplete-uni-patterns` warnings when built with GHC 9.2:

```
[ 3 of 21] Compiling Data.Rep.Internal ( src/Data/Rep/Internal.hs, /home/ryanglscott/Documents/Hacking/Haskell/ci-maintenance/checkout/ekmett/distributive/dist-newstyle/build/x86_64-linux/ghc-9.2.2/distributive-1/build/Data/Rep/Internal.o, /home/ryanglscott/Documents/Hacking/Haskell/ci-maintenance/checkout/ekmett/distributive/dist-newstyle/build/x86_64-linux/ghc-9.2.2/distributive-1/build/Data/Rep/Internal.dyn_o )

src/Data/Rep/Internal.hs:368:41: warning: [-Wincomplete-uni-patterns]
    Pattern match(es) are non-exhaustive
    In a lambda abstraction:
        Patterns of type ‘FCompose a f Identity’ not matched: FCompose' _
    |
368 | distribute = \f -> distrib (FCompose f) \(FCompose f') -> runIdentity <$> f'
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

<and many others...>
```

I believe the underlying cause is the `FCompose` pattern synonym not having a `COMPLETE` pragma. This patch adds one.